### PR TITLE
Run the prepare script during deployment

### DIFF
--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,0 +1,2 @@
+before_release:
+  - ./prepare

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: ./prepare && sentry start
+web: sentry start
 worker: sentry celery worker
 beat: sentry celery beat


### PR DESCRIPTION
On first run, the prepare script runs a large number of database
migrations and may take a while to complete. To prevent long boot
times for the webserver, we run the script in the before_release step.
