### PR TITLE
Update README to include app creation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To run as an app on Aptible:
 
 1. Provision a PostgreSQL database, either from the Aptible Dashboard or the Aptible CLI.
 
+1. Provision an Aptible app, either from the Aptible Dashboard or the Aptible CLI.
+
 1. Configure the following (required and optional) environment variables for your Sentry app:
 
     | Variable | Description | Required? | Default Value |


### PR DESCRIPTION
While somewhat obvious, I think it would be good to explicate the fact that a developer/operator needs to create an application before being able to push up to Aptible.
