### PR TITLE
Upgrade requests from 2.4.3 -> 2.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_ALL en_US.UTF-8
 RUN locale-gen en_US.UTF-8
 
 # Python/pip
-RUN apt-get install -y build-essential python-dev python-pip
+RUN apt-get install -y build-essential python-dev python-pip python-imaging
 
 # PostgreSQL client libraries
 RUN ln -s -f /bin/true /usr/bin/chfn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ amqp==1.0.13
 anyjson==0.3.3
 billiard==2.7.3.34
 celery==3.0.25
+certifi==2018.4.16
+chardet==3.0.4
 cssutils==0.9.10
 dj-database-url==0.3.0
 django-celery==3.0.23
@@ -21,10 +23,12 @@ email-reply-parser==0.2.0
 gunicorn==0.17.4
 httpagentparser==1.2.2
 httplib2==0.9
+idna==2.7
 kombu==2.5.16
 logan==0.5.10
 nydus==0.10.8
 oauth2==1.5.211
+olefile==0.44
 psycopg2==2.5.4
 pynliner==0.5.1
 python-dateutil==1.5
@@ -33,12 +37,12 @@ python-openid==2.2.5
 pytz==2014.7
 raven==5.0.0
 redis==2.8.0
-requests==2.4.3
-sentry==6.4.4
+requests==2.19.1
 sentry-github==0.1.2
 sentry-slack==0.1.0
+sentry==6.4.4
 setproctitle==1.1.8
 simplejson==3.3.3
 six==1.8.0
-urllib3==1.7.1
+urllib3==1.23
 wsgiref==0.1.2


### PR DESCRIPTION
Seems some cleanup of commit details, but wanted to solicit for some early review from Aptible

-- 

* Robyn wasn't getting his Sentry confirmation email...
* Version of requests was really old
  - In fact, so old that we think that CA certs weren't being respected.
  - See [this Slack message][0] for context from @krallin at Aptible.
* Also alphabetized the requirements.txt file

[0]:https://healthify.slack.com/archives/C0L0UKH3K/p1527580004000053